### PR TITLE
Fix transposed characters in documentation

### DIFF
--- a/Conduit.hs
+++ b/Conduit.hs
@@ -3,7 +3,7 @@
 -- This re-exports functions from many commonly used modules.
 -- When there is a conflict with standard functions, functions
 -- in this module are disambiguated by adding a trailing C
--- (or for chunked functions, replacing a trailing E with EC).
+-- (or for chunked functions, replacing a trailing E with CE).
 -- This means that the Conduit module can be imported unqualified
 -- without causing naming conflicts.
 --


### PR DESCRIPTION
Just a tiny pull request to fix the documentation mentioning that chunked functions end in CE.
