### PR TITLE
Fix internal vector growing in sinkVector.

### DIFF
--- a/Data/Conduit/Combinators.hs
+++ b/Data/Conduit/Combinators.hs
@@ -618,8 +618,8 @@ sinkVector = do
     let initSize = 10
     mv0 <- liftBase $ VM.new initSize
     let go maxSize i mv | i >= maxSize = do
-            let newMax = maxSize + 10
-            mv' <- liftBase $ VM.grow mv newMax
+            let newMax = maxSize * 2
+            mv' <- liftBase $ VM.grow mv maxSize
             go newMax i mv'
         go maxSize i mv = do
             mx <- await


### PR DESCRIPTION
A slight oversight mas made in that `VM.grow`'s second parameter (`by`) defines the amount by which the vector's size will be incremented. Thus, the new vector's size will be `(VM.length vec) + by`.
As implemented, the function assumed that the `by` parameter defines the total new size. As a result, the vector's size grew very fast although only a small subset was being used.
I have assumed that a geometric progression with a ratio of 2 was the intended operation and this is what my change implements. I have tested it and it works fine.
Thanks, for all the great work!
