### PR TITLE
fix build under Windows

### DIFF
--- a/Data/Conduit/Combinators.hs
+++ b/Data/Conduit/Combinators.hs
@@ -217,7 +217,10 @@ import Data.Text (Text)
 import qualified System.Random.MWC as MWC
 import Data.Conduit.Combinators.Internal
 import qualified System.PosixCompat.Files as PosixC
+
+#ifndef WINDOWS
 import qualified System.Posix.Directory as Dir
+#endif
 
 #if MIN_VERSION_conduit(1,1,0)
 import qualified Data.Conduit.Filesystem as CF

--- a/Data/Conduit/Combinators/Unqualified.hs
+++ b/Data/Conduit/Combinators/Unqualified.hs
@@ -209,7 +209,10 @@ import Data.Text (Text)
 import qualified System.Random.MWC as MWC
 import Data.Conduit.Combinators.Internal
 import qualified System.PosixCompat.Files as PosixC
+
+#ifndef WINDOWS
 import qualified System.Posix.Directory as Dir
+#endif
 
 #if MIN_VERSION_conduit(1,1,0)
 import qualified Data.Conduit.Filesystem as CF


### PR DESCRIPTION
Module 'System.Posix.Directory' is contained in package 'unix' which is not supported under Windows. And its usage is protected by ifdef already so I think that it is a safe modification.
