### PR TITLE
Data/Conduit/Combinators.hs: fix bad haddock markup

### DIFF
--- a/Data/Conduit/Combinators.hs
+++ b/Data/Conduit/Combinators.hs
@@ -1799,7 +1799,7 @@ vectorBuilder size inner = do
 {-# INLINE vectorBuilder #-}
 
 data S s v e = S
-    {-# UNPACK #-} !Int -- ^ index
+    {-# UNPACK #-} !Int -- index
     !(V.Mutable v s e)
     ([v e] -> [v e])
 


### PR DESCRIPTION
haddock fails as:
  Preprocessing library conduit-combinators-0.2.8.1...
  Haddock coverage:
   100% (  5 /  5) in 'Data.Conduit.Combinators.Internal'
  dist/build/tmp-19228/Data/Conduit/Combinators.hs:1803:5:
      parse error on input ‘!’

Fuuzetsu helped me to find what's exactly wrong:

(19:06:57) Fuuzetsu: slyfox^w_: I think it's bad markup although the error is not great
(19:07:11) Fuuzetsu: you can't documment unnamed constructor fields

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
