### PR TITLE
Fix the capitalisation of Snoyman in the author field

### DIFF
--- a/conduit-combinators.cabal
+++ b/conduit-combinators.cabal
@@ -5,7 +5,7 @@ description:         Provides a replacement for Data.Conduit.List, as well as a 
 homepage:            https://github.com/fpco/conduit-combinators
 license:             MIT
 license-file:        LICENSE
-author:              Michael snoyman
+author:              Michael Snoyman
 maintainer:          michael@snoyman.com
 category:            Data, Conduit
 build-type:          Simple


### PR DESCRIPTION
As it says in the title, I noticed you had your name wrong, which actually matters for the new Hoogle where you can search by author name. I've added a renamings file to fix it in Hoogle, but better to fix upstream too.